### PR TITLE
add check for archive removal, closes #51

### DIFF
--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -121,8 +121,10 @@ module.exports = class ArchivesAPI {
     ])
 
     // remove from the swarm
-    // TODO check if there are other hosting users first
-    /* dont await */ this.archiver.remove(key)
+    var archive = await this.archivesDB.getByKey(key)
+    if (!archive.hostingUsers.length) {
+      /* dont await */ this.archiver.remove(key)
+    }
 
     // respond
     if (contentType === 'html') {


### PR DESCRIPTION
Don't remove an archive from hypercore-archiver if other users have it hosted.

TODO: 

- [x] Test(s)

Trying to figure out if easier way to test would be to manually add an archive to DB or add another user to the `tests/archives`. We'll probably need another user in the archives tests eventually so will probably do that unless you have a different idea.