### PR TITLE
Fix archive progress calculations (close #50)

### DIFF
--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -185,10 +185,7 @@ module.exports = class ArchivesAPI {
 
     // respond
     if (contentType === 'html') {
-      // get progress
-      // TODO add timeout!
       var progress = await this._getArchiveProgress(archive.key)
-
       var {session} = res.locals
       res.render('archive', {
         username,
@@ -210,26 +207,7 @@ module.exports = class ArchivesAPI {
 
   async archiveStatus (req, res) {
     var key = req.path.slice(1)
-
-    // start a timeout
-    var didTimeout = false
-    let to = setTimeout(() => {
-      didTimeout = true
-      if (res.headersSent) {
-        return console.error('Headers already sent on timeout response for', key)
-      }
-      res.status(504).json({
-        message: 'Timed out while searching for the archive',
-        timedOut: true
-      })
-    }, 5e3)
-
-    // fetch the progress
     var progress = await this._getArchiveProgress(key)
-    if (didTimeout) return
-    clearTimeout(to)
-
-    // respond
     res.status(200).json({ progress })
   }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "es6-promisify": "^5.0.0",
     "express": "^4.14.0",
     "express-validator": "^3.1.2",
-    "hypercore-archiver": "^3.2.0",
+    "hypercore-archiver": "^3.3.4",
     "js-yaml": "^3.7.0",
     "jsonwebtoken": "^7.2.1",
     "less-express": "^1.0.1",

--- a/test/archives.js
+++ b/test/archives.js
@@ -291,18 +291,17 @@ test('check archive status after removed', async t => {
   t.is(res.statusCode, 404, '404 not found')
 })
 
-// test('archive status will timeout on archive that fails to sync', async t => {
-//   // add a fake archive
-//   var fakeKey = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-//   var json = {key: fakeKey}
-//   var res = await app.req({uri: '/v1/dats/add', method: 'POST', json, auth})
-//   t.same(res.statusCode, 200, '200 status')
+test('archive status wont stall on archive that fails to sync', async t => {
+  // add a fake archive
+  var fakeKey = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+  var json = {key: fakeKey}
+  var res = await app.req({uri: '/v1/dats/add', method: 'POST', json, auth})
+  t.same(res.statusCode, 200, '200 status')
 
-//   // now ask for the status. since the archive is never found, this should timeout
-//   console.log('waiting for timeout, this should take 5 seconds...')
-//   res = await app.req({uri: `/${fakeKey}`, qs: {view: 'status'}})
-//   t.same(res.statusCode, 504, '504 status')
-// })
+  // now ask for the status. since the archive is never found, this should timeout
+  res = await app.req({uri: `/${fakeKey}`, qs: {view: 'status'}})
+  t.same(res.statusCode, 200, '200 status')
+})
 
 test.cb('stop test server', t => {
   app.close(() => {


### PR DESCRIPTION
Archives that weren't synced yet would stall a request for progress until the first byte had arrived. This PR (mainly updated deps and tests) causes the progress call to respond immediately with 0% if no bytes have been received.