### PR TITLE
Change archive-name rules to disallow periods

### DIFF
--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -62,7 +62,7 @@ module.exports = class ArchiveFilesAPI {
           return archiveRecord
         }
       }
-      
+
       // look up archive record at username
       archiveRecord = userRecord.archives.find(findFn(username))
       if (!archiveRecord) throw new NotFoundError()

--- a/lib/const.js
+++ b/lib/const.js
@@ -1,6 +1,6 @@
 exports.DAT_KEY_REGEX = /([0-9a-f]{64})/i
 exports.DAT_URL_REGEX = /^(dat:\/\/[0-9a-f]{64})/i
-exports.DAT_NAME_REGEX = /^([0-9a-zA-Z-.]*)$/i
+exports.DAT_NAME_REGEX = /^([0-9a-zA-Z-]*)$/i
 
 exports.NotFoundError = class NotFoundError extends Error {
   constructor (message) {

--- a/test/archives.js
+++ b/test/archives.js
@@ -184,7 +184,7 @@ test('change archive name', async t => {
   t.is(res.statusCode, 422, '422 invalid name')
 
   // change name the second time
-  json = {key: testDatKey, name: 'test.dat'}
+  json = {key: testDatKey, name: 'test--dat'}
   res = await app.req.post({uri: '/v1/archives/add', json, auth})
   t.is(res.statusCode, 200, '200 added dat')
 
@@ -192,15 +192,15 @@ test('change archive name', async t => {
   t.is(res.statusCode, 200, '200 got user data')
   t.deepEqual(res.body.archives[0], {
     key: testDatKey,
-    name: 'test.dat'
+    name: 'test--dat'
   })
 
-  res = await app.req.get({url: '/v1/users/admin/test.dat', json: true, auth})
+  res = await app.req.get({url: '/v1/users/admin/test--dat', json: true, auth})
   t.is(res.statusCode, 200, '200 got dat data by name')
   t.deepEqual(res.body, {
     user: 'admin',
     key: testDatKey,
-    name: 'test.dat',
+    name: 'test--dat',
     title: null,
     description: null
   })
@@ -210,7 +210,7 @@ test('change archive name', async t => {
   t.deepEqual(res.body, {
     user: 'admin',
     key: testDatKey,
-    name: 'test.dat',
+    name: 'test--dat',
     title: null,
     description: null
   })


### PR DESCRIPTION
Since archive names are going to be used in subdomains, we either need to disallow periods in the name, or transform the names for serving somehow.

Im suggesting with this PR that we just disallow periods in names.