### PR TITLE
Add event emitters to archivesdb and usersdb

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,4 @@
 
  - [Access Scopes](./schemas/access-scopes.md). The different permissions available to users.
  - [LevelDB](./schemas/leveldb.md). LevelDB layout and objects.
+ - [Events](./schemas/events.md). Events emitted by various components.

--- a/docs/schemas/events.md
+++ b/docs/schemas/events.md
@@ -1,0 +1,21 @@
+## UsersDB
+
+Emits:
+
+```js
+usersDB.on('create', (record) => {})
+usersDB.on('put', (record) => {})
+usersDB.on('del', (record) => {})
+usersDB.on('add-archive', ({userId, archiveKey, name}, record) => {})
+usersDB.on('remove-archive', ({userId, archiveKey}, record) => {})
+```
+
+## ArchivesDB
+
+```js
+archivesDB.emit('create', (record) => {})
+archivesDB.emit('put', (record) => {})
+archivesDB.emit('del', (record) => {})
+archivesDB.emit('add-hosting-user', ({key, userId}, record) => {})
+archivesDB.emit('remove-hosting-user', ({key, userId}, record) => {})
+```

--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -62,7 +62,7 @@ module.exports = class ArchiveFilesAPI {
           return archiveRecord
         }
       }
-      
+
       // look up archive record at username
       archiveRecord = userRecord.archives.find(findFn(username))
       if (!archiveRecord) throw new NotFoundError()

--- a/lib/dbs/archives.js
+++ b/lib/dbs/archives.js
@@ -9,6 +9,8 @@ var lock = require('../lock')
 
 class ArchivesDB extends EventEmitter {
   constructor (cloud) {
+    super()
+
     // create levels and indexer
     this.archivesDB = sublevel(cloud.db, 'archives', { valueEncoding: 'json' })
     this.deadArchivesDB = sublevel(cloud.db, 'dead-archives')

--- a/lib/dbs/archives.js
+++ b/lib/dbs/archives.js
@@ -1,3 +1,4 @@
+var EventEmitter = require('events')
 var assert = require('assert')
 var levelPromise = require('level-promise')
 var sublevel = require('subleveldown')
@@ -6,7 +7,7 @@ var lock = require('../lock')
 // exported api
 // =
 
-class ArchivesDB {
+class ArchivesDB extends EventEmitter {
   constructor (cloud) {
     // create levels and indexer
     this.archivesDB = sublevel(cloud.db, 'archives', { valueEncoding: 'json' })
@@ -25,6 +26,7 @@ class ArchivesDB {
     record = Object.assign({}, ArchivesDB.defaults, record)
     record.createdAt = Date.now()
     await this.put(record)
+    this.emit('create', record)
     return record
   }
 
@@ -32,15 +34,15 @@ class ArchivesDB {
     assert(typeof record.key === 'string')
     record.updatedAt = Date.now()
     await this.archivesDB.put(record.key, record)
+    this.emit('put', record)
   }
 
-  async del (key) {
-    if (key && typeof key === 'object' && key.key) {
-      key = key.key
-    }
-    assert(typeof key === 'string')
-    await this.archivesDB.del(key)
-    /* dont await */ this.deadArchivesDB.del(key)
+  async del (record) {
+    assert(record && typeof record === 'object')
+    assert(typeof record.key === 'string')
+    await this.archivesDB.del(record.key)
+    /* dont await */ this.deadArchivesDB.del(record.key)
+    this.emit('del', record)
   }
 
   // getters
@@ -93,6 +95,7 @@ class ArchivesDB {
     } finally {
       release()
     }
+    this.emit('add-hosting-user', {key, userId}, archiveRecord)
 
     // track dead archives
     /* dont await */ this.updateDeadArchives(key, archiveRecord.hostingUsers.length)
@@ -116,6 +119,7 @@ class ArchivesDB {
     } finally {
       release()
     }
+    this.emit('remove-hosting-user', {key, userId}, archiveRecord)
 
     // track dead archives
     /* dont await */ this.updateDeadArchives(key, archiveRecord.hostingUsers.length)

--- a/lib/dbs/users.js
+++ b/lib/dbs/users.js
@@ -13,6 +13,7 @@ var lock = require('../lock')
 
 class UsersDB extends EventEmitter {
   constructor (cloud) {
+    super()
     // create levels and indexer
     this.accountsDB = sublevel(cloud.db, 'accounts', { valueEncoding: 'json' })
     this.indexDB = sublevel(cloud.db, 'accounts-index')

--- a/lib/dbs/users.js
+++ b/lib/dbs/users.js
@@ -4,13 +4,14 @@ var levelPromise = require('level-promise')
 var createIndexer = require('level-simple-indexes')
 var sublevel = require('subleveldown')
 var collect = require('stream-collector')
+var EventEmitter = require('events')
 var { promisifyModule } = require('../helpers')
 var lock = require('../lock')
 
 // exported api
 // =
 
-class UsersDB {
+class UsersDB extends EventEmitter {
   constructor (cloud) {
     // create levels and indexer
     this.accountsDB = sublevel(cloud.db, 'accounts', { valueEncoding: 'json' })
@@ -40,6 +41,7 @@ class UsersDB {
     record.id = monotonicTimestamp().toString(36)
     record.createdAt = Date.now()
     await this.put(record)
+    this.emit('create', record)
     return record
   }
 
@@ -53,6 +55,7 @@ class UsersDB {
     } finally {
       release()
     }
+    this.emit('put', record)
   }
 
   async del (record) {
@@ -64,6 +67,7 @@ class UsersDB {
     } finally {
       release()
     }
+    this.emit('del', record)
   }
 
   // getters
@@ -163,6 +167,7 @@ class UsersDB {
     } finally {
       release()
     }
+    this.emit('add-archive', {userId, archiveKey, name}, userRecord)
   }
 
   async removeArchive (userId, archiveKey) {
@@ -183,6 +188,7 @@ class UsersDB {
     } finally {
       release()
     }
+    this.emit('remove-archive', {userId, archiveKey}, userRecord)
   }
 }
 module.exports = UsersDB


### PR DESCRIPTION
Events will make it possible for UI modules to hook into the core data model and write extension records. For example, to extend the user model:

```js
cloud.usersDB.on('create', record => {
  myUsersDB.put(record.id, {extra: 'attributes'})
})
cloud.usersDB.on('del', record => {
  myUsersDB.del(record.id)
})
```