### PR TITLE
Update Dat name validation message

### DIFF
--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -23,7 +23,7 @@ module.exports = class ArchivesAPI {
     req.checkBody('key').optional().isDatHash()
     req.checkBody('url').optional().isDatURL()
     req.checkBody('name').optional()
-      .isDatName().withMessage('Names must only contain characters, numbers, periods, and dashes.')
+      .isDatName().withMessage('Names must only contain characters, numbers, and dashes.')
       .isLength({ min: 3, max: 63 }).withMessage('Names must be 3-63 characters long.')
     ;(await req.getValidationResult()).throw()
     if (req.body.url) req.sanitizeBody('url').toDatDomain()


### PR DESCRIPTION
We shouldn't allow periods in the archive name. DAT_NAME_REGEX is correct
as is.