### PR TITLE
Temporary rule: one hosting-user per dat

### DIFF
--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -54,10 +54,19 @@ module.exports = class ArchivesAPI {
     }
 
     // update the records
-    await Promise.all([
-      this.usersDB.addArchive(userRecord.id, key, name),
-      this.archivesDB.addHostingUser(key, userRecord.id)
-    ])
+    // TEMPORARY we have to do addHostingUser first, and cancel if that fails
+    // await Promise.all([
+    //   this.usersDB.addArchive(userRecord.id, key, name),
+    //   this.archivesDB.addHostingUser(key, userRecord.id)
+    // ])
+    try {
+      await this.archivesDB.addHostingUser(key, userRecord.id)
+    } catch (e) {
+      return res.status(422).json({
+        message: 'This archive is already being hosted by someone else'
+      })
+    }
+    await this.usersDB.addArchive(userRecord.id, key, name)
 
     // record the event
     /* dont await */ this.activityDB.writeGlobalEvent({

--- a/lib/dbs/archives.js
+++ b/lib/dbs/archives.js
@@ -164,9 +164,15 @@ class ArchivesDB extends EventEmitter {
       if (archiveRecord.hostingUsers.includes(userId)) {
         return // already hosting
       }
-      archiveRecord.hostingUsers.push(userId)
+
+      // TEMPORARY
+      // only allow one hosting user per archive
+      if (archiveRecord.hostingUsers.length > 0) {
+        throw new Error('Cant add another user')
+      }
 
       // update records
+      archiveRecord.hostingUsers.push(userId)
       await this.put(archiveRecord)
     } finally {
       release()

--- a/lib/dbs/archives.js
+++ b/lib/dbs/archives.js
@@ -42,7 +42,7 @@ class ArchivesDB extends EventEmitter {
   async create (record) {
     assert(record && typeof record === 'object')
     assert(typeof record.key === 'string')
-    record = Object.assign({}, ArchivesDB.defaults, record)
+    record = Object.assign({}, ArchivesDB.defaults(), record)
     record.createdAt = Date.now()
     await this.put(record)
     await this.indexer.updateIndexes(record)
@@ -228,11 +228,11 @@ class ArchivesDB extends EventEmitter {
 module.exports = ArchivesDB
 
 // default user-record values
-ArchivesDB.defaults = {
+ArchivesDB.defaults = () => ({
   key: null,
 
   hostingUsers: [],
 
   updatedAt: 0,
   createdAt: 0
-}
+})

--- a/test/archives.js
+++ b/test/archives.js
@@ -123,29 +123,35 @@ test('read back archive', async t => {
   })
 })
 
-test('add duplicate archive as another user', async t => {
+// TEMPORARY - hypercloud only allows one hosting user per archive
+// test('add duplicate archive as another user', async t => {
+//   var json = {key: testDatKey}
+//   var res = await app.req.post({uri: '/v1/archives/add', json, auth: authUser})
+//   t.is(res.statusCode, 200, '200 added dat')
+
+//   res = await app.req.get({url: '/v1/users/bob?view=archives', json: true, auth: authUser})
+//   t.is(res.statusCode, 200, '200 got user data')
+//   t.deepEqual(res.body.archives[0], {
+//     key: testDatKey,
+//     name: null,
+//     title: 'Test Dat 1',
+//     description: 'The first test dat'
+//   })
+
+//   res = await app.req.get({url: '/v1/users/bob/' + testDatKey, json: true, auth: authUser})
+//   t.is(res.statusCode, 200, '200 got dat data')
+//   t.deepEqual(res.body, {
+//     user: 'bob',
+//     key: testDatKey,
+//     name: null,
+//     title: 'Test Dat 1',
+//     description: 'The first test dat'
+//   })
+// })
+test('dont allow duplicate archives as another user', async t => {
   var json = {key: testDatKey}
   var res = await app.req.post({uri: '/v1/archives/add', json, auth: authUser})
-  t.is(res.statusCode, 200, '200 added dat')
-
-  res = await app.req.get({url: '/v1/users/bob?view=archives', json: true, auth: authUser})
-  t.is(res.statusCode, 200, '200 got user data')
-  t.deepEqual(res.body.archives[0], {
-    key: testDatKey,
-    name: null,
-    title: 'Test Dat 1',
-    description: 'The first test dat'
-  })
-
-  res = await app.req.get({url: '/v1/users/bob/' + testDatKey, json: true, auth: authUser})
-  t.is(res.statusCode, 200, '200 got dat data')
-  t.deepEqual(res.body, {
-    user: 'bob',
-    key: testDatKey,
-    name: null,
-    title: 'Test Dat 1',
-    description: 'The first test dat'
-  })
+  t.is(res.statusCode, 422, '422 rejected')
 })
 
 test('add archive that was already added', async t => {
@@ -315,16 +321,17 @@ test('remove archive', async t => {
   t.is(res.statusCode, 200, '200 removed dat')
 })
 
-test('check archive status after removed by one user, not all', async t => {
-  var res = await app.req({uri: `/v1/archives/${testDatKey}`, qs: {view: 'status'}, auth})
-  t.is(res.statusCode, 200, '200 got dat')
-})
+// TEMPORARY only 1 owner per archive allowed
+// test('check archive status after removed by one user, not all', async t => {
+//   var res = await app.req({uri: `/v1/archives/${testDatKey}`, qs: {view: 'status'}, auth})
+//   t.is(res.statusCode, 200, '200 got dat')
+// })
 
-test('remove archive as other user', async t => {
-  var json = {key: testDatKey}
-  var res = await app.req.post({uri: '/v1/archives/remove', json, auth: authUser})
-  t.is(res.statusCode, 200, '200 removed dat')
-})
+// test('remove archive as other user', async t => {
+//   var json = {key: testDatKey}
+//   var res = await app.req.post({uri: '/v1/archives/remove', json, auth: authUser})
+//   t.is(res.statusCode, 200, '200 removed dat')
+// })
 
 test('remove archive that was already removed', async t => {
   var json = {key: testDatKey}


### PR DESCRIPTION
I discovered a mistake in the data model: the archive records have a `name` entry which is set when a user uploads an archive. But, multiple users can upload the same archive. That means we need each user to have their own name for each 'upload' of the archive.

Having multiple names and owners creates some problems though. In our hashbase UI, we have a "leaderboard" of the most popular dats (by peer count). We'd like to have an "authoring user" on that listing. Multiple users complicates that situation -- though we could handle that by just using the first user to do an upload.

For now, this PR modifies the archives so that only one user can upload an archive. In the future, we can replace this with a data model update that supports multiple names per archive.