### PR TITLE
Update per-archive http hosting to use a dash separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,14 +51,8 @@ module.exports = function (config) {
   if (config.sites) {
     var httpGatewayApp = express()
     httpGatewayApp.get('/.well-known/dat', cloud.api.archiveFiles.getDNSFile)
-    if (config.sites === 'per-archive') {
-      httpGatewayApp.get('*', cloud.api.archiveFiles.getFile)
-      app.use(vhost('*.*.' + config.hostname, httpGatewayApp))
-      app.use(vhost('*.' + config.hostname, httpGatewayApp))
-    } else {
-      httpGatewayApp.get('*', cloud.api.archiveFiles.getFile)
-      app.use(vhost('*.' + config.hostname, httpGatewayApp))
-    }
+    httpGatewayApp.get('*', cloud.api.archiveFiles.getFile)
+    app.use(vhost('*.' + config.hostname, httpGatewayApp))
   }
 
   // service apis

--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -27,13 +27,14 @@ module.exports = class ArchiveFilesAPI {
     const findFn = test => a => a.name.toLowerCase() === test
 
     if (this.config.sites === 'per-archive') {
-      if (!req.vhost[1]) {
+      let vhostParts = req.vhost[0].split('-')
+      if (vhostParts.length === 1) {
         // user.domain
-        username = archname = req.vhost[0]
+        username = archname = vhostParts[0]
       } else {
-        // archive.user.domain
-        archname = req.vhost[0]
-        username = req.vhost[1]
+        // archive-user.domain
+        archname = vhostParts.slice(0, -1).join('-')
+        username = vhostParts[vhostParts.length - 1]
       }
 
       // lookup user record

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Note that, in this scheme, a DNS shortname is only provided for the user archive
 sites: per-archive
 ```
 
-Per-archive will host archives at `archivename.username.hostname`. If the archive-name is == to the username, it will be hosted at `username.hostname`.
+Per-archive will host archives at `archivename-username.hostname`. If the archive-name is == to the username, it will be hosted at `username.hostname`.
 
 By default, HTTP Sites are disabled.
 


### PR DESCRIPTION
The current per-archive scheme uses 2 levels of subdomain. Unfortunately there's no TLS cert system that will allow you to do that-- wildcards dont support more than 1 level, and lets-encrypt is rate limited to something like 20 subdomains a week.

This changes the scheme from `arch.user.hostname` to `arch-user.hostname`. (Users cant have dashes in their names.)