### PR TITLE
Add admin endpoint to send a generic email to any user

### DIFF
--- a/docs/webapis.md
+++ b/docs/webapis.md
@@ -38,6 +38,7 @@ POST /v1/admin/users/:id - update user settings
 POST /v1/admin/users/:id/suspend - suspend a user account
 POST /v1/admin/users/:id/unsuspend - unsuspend a user account
 GET /v1/admin/archives/:key - get archive information
+POST /v1/admin/users/:username/send-email - send an email to the user
 ```
 
 ## Service APIs

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ module.exports = function (config) {
   app.post('/v1/admin/users/:id', cloud.api.admin.updateUser)
   app.post('/v1/admin/users/:id/suspend', cloud.api.admin.suspendUser)
   app.post('/v1/admin/users/:id/unsuspend', cloud.api.admin.unsuspendUser)
+  app.post('/v1/admin/users/:username/send-email', cloud.api.admin.sendEmail)
   app.get('/v1/admin/archives/:key', cloud.api.admin.getArchive)
 
   // (json) error-handling fallback

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -151,6 +151,7 @@ module.exports = class AdminAPI {
 
   async sendEmail (req, res) {
     // check perms
+    if (!res.locals.session) throw new UnauthorizedError()
     if (!res.locals.session.scopes.includes('admin:users')) throw new ForbiddenError()
 
     var {message, subject, username} = req.body

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -8,6 +8,8 @@ module.exports = class AdminAPI {
   constructor (cloud) {
     this.usersDB = cloud.usersDB
     this.archiver = cloud.archiver
+    this.mailer = cloud.mailer
+    this.config = cloud.config
   }
 
   async listUsers (req, res) {
@@ -145,6 +147,30 @@ module.exports = class AdminAPI {
       swarmOpts: archive.swarmOpts,
       diskUsage: archive.diskUsage
     })
+  }
+
+  async sendEmail (req, res) {
+    // check perms
+    if (!res.locals.session.scopes.includes('admin:users')) throw new ForbiddenError()
+
+    var {message, subject, username} = req.body
+    if (!(message && subject && username)) return res.status(422).json({
+      message: 'Must include a message and subject line'
+    })
+
+    // fetch user record
+    var userRecord = await this.usersDB.getByUsername(username)
+
+    if (!userRecord) throw new NotFoundError()
+
+    this.mailer.send('support', {
+      email: userRecord.email,
+      subject,
+      message,
+      username,
+      brandname: this.config.brandname
+    })
+    res.status(200).end()
   }
 
   async _getUser (id) {

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -3,7 +3,8 @@ var nodemailer = require('nodemailer')
 var templates = {
   verification: require('./templates/mail/verification'),
   'forgot-password': require('./templates/mail/forgot-password'),
-  'verify-update-email': require('./templates/mail/verify-update-email')
+  'verify-update-email': require('./templates/mail/verify-update-email'),
+  'support': require('./templates/mail/support')
 }
 
 // exported api

--- a/lib/templates/mail/support.js
+++ b/lib/templates/mail/support.js
@@ -1,0 +1,23 @@
+exports.subject = function (params) {
+  return params.subject
+}
+
+exports.text = function (params) {
+  console.log(params)
+  return `
+    ${params.username},\n
+    \n
+    ${params.message}\n
+    \n
+    Thanks,\n
+    The ${params.brandname} team
+  `
+}
+
+exports.html = function (params) {
+  return `
+    <p>${params.username},</p>
+    <p>${params.message}</p>
+    <p>Thanks,<br>The ${params.brandname} team</p>
+  `
+}

--- a/test/admin.js
+++ b/test/admin.js
@@ -345,6 +345,27 @@ test('bob can login when unsuspended', async t => {
   t.is(res.statusCode, 200, '200 can login when unsuspended')
 })
 
+test('send support email', async t => {
+  var res, lastMail
+
+  res = await app.req.post({
+    uri: '/v1/admin/users/alice/send-email',
+    json: {
+      username: 'alice',
+      subject: 'The subject line',
+      message: 'The message'
+    },
+    auth
+  })
+  t.is(res.statusCode, 200)
+
+  // check sent mail and extract the verification nonce
+  lastMail = app.cloud.mailer.transport.sentMail.pop()
+  t.truthy(lastMail)
+  t.is(lastMail.data.subject, 'The subject line')
+  t.truthy(lastMail.data.text.includes('The message'))
+})
+
 test.cb('stop test server', t => {
   app.close(() => {
     t.pass('closed')


### PR DESCRIPTION
This adds an endpoint `/v1/admin/users/:username/send-email/` for sending a generic email to any user of the form:

```
{username},

{message}

Thanks,
The {config.brandname} team
```