### PR TITLE
Add endpoint for admin to create new users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+  - "8"

--- a/docs/webapis.md
+++ b/docs/webapis.md
@@ -33,6 +33,7 @@ Admin APIs
 
 ```
 GET  /v1/admin/users - query users
+POST  /v1/admin/users - create new user
 GET  /v1/admin/users/:id - get user info & settings
 POST /v1/admin/users/:id - update user settings
 POST /v1/admin/users/:id/suspend - suspend a user account
@@ -315,6 +316,24 @@ Response body:
     updatedAt: Number, the timestamp of the last update
     createdAt: Number, the timestamp of creation time
   }, ...]
+}
+```
+
+Scope: `admin:users`
+
+### POST /v1/admin/users
+
+Create a new user as admin. Skips email verification.
+
+Request body:
+
+Username is the only required field.
+
+```
+{
+  email: String
+  username: String
+  password: String
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ module.exports = function (config) {
   // =
 
   app.get('/v1/admin/users', cloud.api.admin.listUsers)
+  app.post('/v1/admin/users', cloud.api.admin.createUser)
   app.get('/v1/admin/users/:id', cloud.api.admin.getUser)
   app.post('/v1/admin/users/:id', cloud.api.admin.updateUser)
   app.post('/v1/admin/users/:id/suspend', cloud.api.admin.suspendUser)

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -43,6 +43,59 @@ module.exports = class AdminAPI {
     res.json(user)
   }
 
+  async createUser (req, res) {
+    // check perms
+    if (!res.locals.session) throw new UnauthorizedError()
+    if (!res.locals.session.scopes.includes('admin:users')) throw new ForbiddenError()
+
+    // validate & sanitize input
+    req.checkBody('username')
+      .isAlphanumeric().withMessage('Can only be letters and numbers.')
+      .isLength({ min: 3, max: 16 }).withMessage('Must be 3 to 16 characters.')
+    req.checkBody('email', 'Must be a valid email').optional()
+      .isEmail()
+      .isLength({ min: 3, max: 100 })
+    req.checkBody('password', 'Must be 6 to 100 characters.').optional()
+      .isLength({ min: 6, max: 100 })
+    ;(await req.getValidationResult()).throw()
+    var {username, email, password} = req.body
+
+    var release = await lock('users')
+    try {
+      // check email & username availability
+      let error = false
+      if (email && await this.usersDB.isEmailTaken(email)) {
+        error = {
+          message: 'Email is not available',
+          emailNotAvailable: true
+        }
+      } else if (await this.usersDB.isUsernameTaken(username)) {
+        error = {
+          message: 'Username is not available',
+          usernameNotAvailable: true
+        }
+      }
+
+      // render error
+      if (error) {
+        return res.status(422).json(error)
+      }
+
+      // create user record
+      var record = await this.usersDB.create({
+        username,
+        email,
+        password
+      })
+    } finally {
+      release()
+    }
+
+    // respond
+    res.status(201)
+    res.json({id: record.id, email: record.email})
+  }
+
   async updateUser (req, res) {
     // check perms
     if (!res.locals.session) throw new UnauthorizedError()

--- a/test/admin.js
+++ b/test/admin.js
@@ -258,6 +258,45 @@ test('get user', async t => {
   t.is(res.body.username, testUser.username)
 })
 
+test('create new user via admin without email', async t => {
+  var res = await app.req.post({
+    uri: '/v1/admin/users',
+    json: {
+      username: 'bobita'
+    },
+    auth
+  })
+  t.is(res.statusCode, 201, '201 created user')
+
+  res = await app.req.get({
+    uri: '/v1/admin/users/bobita',
+    json: true,
+    auth
+  })
+  t.is(res.statusCode, 200, '200 got')
+  t.is(res.body.username, 'bobita', 'is created')
+})
+
+test('create new user via admin with email', async t => {
+  var res = await app.req.post({
+    uri: '/v1/admin/users',
+    json: {
+      username: 'bobitaToo',
+      email: 'bobita@example.com'
+    },
+    auth
+  })
+  t.is(res.statusCode, 201, '201 created user')
+
+  res = await app.req.get({
+    uri: '/v1/admin/users/bobitaToo',
+    json: true,
+    auth
+  })
+  t.is(res.statusCode, 200, '200 got')
+  t.is(res.body.username, 'bobitaToo', 'is created')
+})
+
 test('fully update carla', async t => {
   var res = await app.req.post({
     uri: '/v1/admin/users/carla',


### PR DESCRIPTION
Allows admins to create users. This allows skipping of email registration. Useful for centrally managing users or bulk creating users as admin.